### PR TITLE
Bumping nltk to 3.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==2.3.2
 Flask-PyMongo==2.3.0
-nltk==3.6.7
+nltk==3.8.1
 pandas==1.4.3
 requests==2.27.1
 python-dotenv==0.20.0


### PR DESCRIPTION
To resolve CVE-2024-39705, bumping `nltk` module to 3.8.1